### PR TITLE
feat: publicar versión inicial de la API de códigos postales de Chile

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Seguir el siguiente formato:
 ### Mapas / Geocodificación
 
 - [API Planos.cl](http://apiplanos.amarillas.cl/): API Planos.cl de hibu está conformada por clases desarrolladas en lenguaje Javascript.
+- [KaiNext Postal Code API](https://postal-code-api.kainext.cl/v1/api): API gratuita y pública para obtener códigos postales en Chile a partir de comuna, calle y número. Si el dato no está en la base, realiza scraping inteligente al sitio oficial de Correos de Chile, lo guarda y lo entrega en consultas futuras de forma casi instantánea. Además, expone endpoints para obtener las 16 regiones y 346 comunas del país, ordenadas y estructuradas. No requiere autenticación ni tokens, y está pensada para ser simple, útil y abierta para todos.
 - ~[API de Mapas y Geocodificación de Mapcity](http://api.mapcity.com/docs/tutorial.php): La API de MapCity es una extensión de Openlayers y ExtCore. Los tipos básicos de la API y los controles son derivados de los tipos y controles de OpenLayers, por lo tanto la mayoría de las funciones de OpenLayers aplican a las funciones de la API.~ [DEPRECATED]
 
 


### PR DESCRIPTION
### Qué incluye este PR

Este PR publica la primera versión estable de la **KaiNext Postal Code API**, una API gratuita y pública para obtener códigos postales en Chile.

#### Funcionalidades principales

- 🔍 Búsqueda de código postal por comuna, calle y número
- 🧠 Búsqueda con scraping automático al sitio de Correos de Chile si el dato no está en la base
- 💾 Persistencia automática del código postal para futuras consultas
- 📚 Endpoints públicos para obtener:
  - Las 16 regiones de Chile
  - Las 346 comunas del país, ordenadas alfabéticamente
- 🛡️ API sin autenticación ni tokens, pensada para ser libre y accesible
- 📄 Documentación Swagger disponible en `/v1/api`

#### Tecnologías utilizadas

- NestJS + Fastify
- Playwright para scraping
- TypeORM con PostgreSQL
- Railway para despliegue
- Swagger para documentación automática